### PR TITLE
Fix EEPROM flash address freezing the board

### DIFF
--- a/Marlin/src/pins/stm32f4/pins_FYSETC_CHEETAH_V30.h
+++ b/Marlin/src/pins/stm32f4/pins_FYSETC_CHEETAH_V30.h
@@ -38,9 +38,6 @@
   #define FLASH_EEPROM_EMULATION
   #define FLASH_EEPROM_LEVELING
 
-  #define FLASH_SECTOR          1
-  #define FLASH_UNIT_SIZE       0x4000      // 16k
-  #define FLASH_ADDRESS_START   0x8004000
 #endif
 
 //


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description

This pull request addresses an issue encountered when compiling Marlin firmware for the CHEETAH V30 motherboard. The problem led to the board freezing on startup with a blank screen.

Upon flashing the firmware to the CHEETAH V30 board, it was observed that the board would not initialize properly, resulting in a blank screen during startup. This behavior was indicative of an issue in the firmware configuration specific to this motherboard.

Upon investigation, I've discovered that the EEPROM configuration for the CHEETAH V30 was identical to that of the CHEETAH V20, despite the two boards having different CPUs. This inconsistency suggested that the EEPROM configuration was not adapted to the new hardware.

To confirm my hypothesis, I compared the EEPROM configuration of the CHEETAH V30 with that of other boards using the same CPU, such as the FYSETC S6. It became evident that the CHEETAH V30 defines for the EEPROM flash address could be causing some conflicts in the board's operation.

To resolve this issue, I commented out the following lines in the pins .h file, which were defining the EEPROM flash address for the CHEETAH V30:
`#define FLASH_SECTOR          1`
`#define FLASH_UNIT_SIZE       0x4000      // 16k`
`#define FLASH_ADDRESS_START   0x8004000`
### Requirements

CHEETAH V30 motherboard.

### Benefits

This pull request addresses the startup freezing issue in Marlin firmware for the CHEETAH V30 motherboard by adjusting the EEPROM configuration.

